### PR TITLE
feat: adds the constructor of a feature to the features querystring if the specific feature does not exist from within polyfill-library

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,15 @@ async function generatePolyfillURL(features = []) {
     for (const feature of features) {
         if (polyfills.includes(feature)) {
             featuresInPolyfillLibrary.add(feature);
-        } else if (feature in aliases){
-                featuresInPolyfillLibrary.add(feature);
+        } else if (feature in aliases) {
+            featuresInPolyfillLibrary.add(feature);
+        } else if (feature.includes('.prototype')) {
+            const featureConstructor = feature.split('.prototype')[0];
+            if (polyfills.includes(featureConstructor)) {
+                featuresInPolyfillLibrary.add(featureConstructor);
+            } else if (featureConstructor in aliases) {
+                featuresInPolyfillLibrary.add(featureConstructor);
+            }
         }
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,3 +37,11 @@ test('Adds an alias to the features querystring if it matches multiple features 
     expect(actual).toEqual(expected);
 });
 
+test('Adds the constructor of a feature to the features querystring if the specific feature does not exist from within polyfill-library', async () => {
+    const expected = 'https://cdn.polyfill.io/v3/polyfill.min.js?features=DOMTokenList';
+    const actual = await generatePolyfillURL([
+        "DOMTokenList.prototype.add"
+    ]);
+    expect(actual).toEqual(expected);
+});
+


### PR DESCRIPTION


We do not currently have an alias for all the prototype methods that are polyfilled when adding a
polyfill for an entire object such as `Set`, `Map`, `DOMTokenList`. Because of this we currently do
not add those objects to the polyfill.io url when they are present in the features array. This
change adds the ability for the tool to add the constructor/object when it exists and the specific
prototype method polyfill/alias does not exist.