### PR TITLE
feat: added browserslist support

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,15 @@ require("yargs")
             demandOption: true
         }
     }, async function parseFile(argv) {
+        const browserslist = require('browserslist');
+        const browsersListConfig = browserslist.loadConfig({
+            path:  process.cwd()
+        })
+        let browsers = []
+        if (browsersListConfig) {
+            browsers = browserslist(browsersListConfig);
+        }
+
         const generatePolyfillURL = require('./src/index.js');
         const path = require('path');
         const babel = require("@babel/core");
@@ -40,7 +49,7 @@ require("yargs")
                 code: false
             });
             
-            console.log(await generatePolyfillURL(JSON.parse(fs.readFileSync(outputDestination, 'utf-8'))));
+            console.log(await generatePolyfillURL(JSON.parse(fs.readFileSync(outputDestination, 'utf-8')), browsers));
 
         } catch (error) {
             if (error instanceof SyntaxError) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,13 @@
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "@babel/generator": {
@@ -510,6 +517,13 @@
       "requires": {
         "@financial-times/useragent_parser": "^1.2.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "@financial-times/useragent_parser": {
@@ -2309,6 +2323,16 @@
         }
       }
     },
+    "browserslist": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.3.tgz",
+      "integrity": "sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==",
+      "requires": {
+        "caniuse-lite": "^1.0.30001017",
+        "electron-to-chromium": "^1.3.322",
+        "node-releases": "^1.1.44"
+      }
+    },
     "bser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
@@ -2408,6 +2432,11 @@
           "dev": true
         }
       }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001020",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001020.tgz",
+      "integrity": "sha512-yWIvwA68wRHKanAVS1GjN8vajAv7MBFshullKCeq/eKpK7pJBVDgFFEqvgWTkcP2+wIDeQGYFRXECjKZnLkUjA=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -2746,6 +2775,12 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -2870,6 +2905,13 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "cssom": {
@@ -3198,6 +3240,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.332",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.332.tgz",
+      "integrity": "sha512-AP2HkLhfSOIxP7gDjlyZ4ywGWIcxRMZoU9+JriuVkQe2pSLDdWBsE6+eI6BQOqun1dohLrUTOPHsQLLhhFA7Eg=="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -6481,6 +6528,14 @@
         "natural-compare": "^1.4.0",
         "pretty-format": "^24.8.0",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "jest-util": {
@@ -6952,6 +7007,12 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -7297,6 +7358,29 @@
         "semver": "^5.5.0",
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "node-releases": {
+      "version": "1.1.45",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.45.tgz",
+      "integrity": "sha512-cXvGSfhITKI8qsV116u2FTzH5EWZJfgG7d4cpqwF8I8+1tWpD6AsvvGRKq2onR0DNj1jfqsjkXZsm14JMS7Cyg==",
+      "requires": {
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "normalize-package-data": {
@@ -7309,6 +7393,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -12332,9 +12424,9 @@
       }
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.1.tgz",
+      "integrity": "sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A=="
     },
     "semver-regex": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
   "dependencies": {
     "@babel/core": "^7.5.5",
     "@financial-times/js-features-analyser": "0.0.4",
+    "browserslist": "^4.8.3",
     "execa": "^2.0.3",
     "polyfill-library": "^3.37.0",
+    "semver": "^7.1.1",
     "yargs": "^13.3.0"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,44 +1,153 @@
 "use strict";
 
 const polyfillLibrary = require("polyfill-library");
+const UA = require("@financial-times/polyfill-useragent-normaliser");
+const semver = require("semver");
+/*
+[
+  'android',     'bb',
+  'chrome',      'edge',
+  'edge_mob',    'firefox',
+  'firefox_mob', 'ie',
+  'ie_mob',      'ios_chr',
+  'ios_saf',     'op_mini',
+  'op_mob',      'opera',
+  'safari',      'samsung_mob'
+]
+*/
+const browserBaselines = UA.getBaselines();
 
-async function generatePolyfillURL(features = []) {
-    const polyfillUrl = 'https://cdn.polyfill.io/v3/polyfill.min.js';
-    const aliases = await polyfillLibrary.listAliases();
-    const polyfills = await polyfillLibrary.listAllPolyfills();
-    const featuresInPolyfillLibrary = new Set;
+/*
+[
+  'and_chr', 'and_ff',  'and_qq',
+  'and_uc',  'android', 'baidu',
+  'bb',      'chrome',  'edge',
+  'firefox', 'ie',      'ie_mob',
+  'ios_saf', 'kaios',   'node',
+  'op_mini', 'op_mob',  'opera',
+  'safari',  'samsung'
+]
+*/
 
-    for (const feature of features) {
-        if (polyfills.includes(feature)) {
-            featuresInPolyfillLibrary.add(feature);
-        } else if (feature in aliases) {
-            featuresInPolyfillLibrary.add(feature);
-        } else if (feature.includes('.prototype')) {
-            const featureConstructor = feature.split('.prototype')[0];
-            if (polyfills.includes(featureConstructor)) {
-                featuresInPolyfillLibrary.add(featureConstructor);
-            } else if (featureConstructor in aliases) {
-                featuresInPolyfillLibrary.add(featureConstructor);
-            }
+function normaliseBrowsers(browsers) {
+  return Array.from(
+    new Set(
+      browsers.map(b => {
+        let [name, range] = b.split(" ");
+        switch (name) {
+          case "and_chr": {
+            name = "chrome";
+            break;
+          }
+          case "and_ff": {
+            name = "firefox_mob";
+            break;
+          }
+          case "samsung": {
+            name = "samsung_mob";
+            break;
+          }
         }
-    }
+        return name + " " + semver.coerce(range, { loose: true }).toString();
+      })
+    ),
+    a => a.split(" ")
+  );
+}
+async function generatePolyfillURL(features = [], supportedBrowsers = []) {
+  if (supportedBrowsers) {
+    supportedBrowsers = normaliseBrowsers(supportedBrowsers);
+  }
+  const polyfillUrl = "https://cdn.polyfill.io/v3/polyfill.min.js";
+  const aliases = await polyfillLibrary.listAliases();
+  const polyfills = await polyfillLibrary.listAllPolyfills();
+  const featuresInPolyfillLibrary = new Set();
 
-    for (const [alias, polyfills] of Object.entries(aliases)) {
-        if (polyfills.length > 2) {
-            const allPolyfillsInAliasAreInFeatures = polyfills.every(polyfill => featuresInPolyfillLibrary.has(polyfill));
-            if (allPolyfillsInAliasAreInFeatures) {
-                featuresInPolyfillLibrary.add(alias);
-                polyfills.forEach(polyfill => featuresInPolyfillLibrary.delete(polyfill));
+  for (const feature of features) {
+    if (polyfills.includes(feature)) {
+      featuresInPolyfillLibrary.add(feature);
+    } else if (feature in aliases) {
+      featuresInPolyfillLibrary.add(feature);
+    } else if (feature.includes(".prototype")) {
+      const featureConstructor = feature.split(".prototype")[0];
+      if (polyfills.includes(featureConstructor)) {
+        featuresInPolyfillLibrary.add(featureConstructor);
+      } else if (featureConstructor in aliases) {
+        featuresInPolyfillLibrary.add(featureConstructor);
+      }
+    }
+  }
+
+  for (const [alias, polyfills] of Object.entries(aliases)) {
+    if (polyfills.length > 2) {
+      const allPolyfillsInAliasAreInFeatures = polyfills.every(polyfill =>
+        featuresInPolyfillLibrary.has(polyfill)
+      );
+      if (allPolyfillsInAliasAreInFeatures) {
+        featuresInPolyfillLibrary.add(alias);
+        polyfills.forEach(polyfill =>
+          featuresInPolyfillLibrary.delete(polyfill)
+        );
+      }
+    }
+  }
+
+  if (supportedBrowsers.length > 0) {
+    for (const feature of featuresInPolyfillLibrary) {
+      const featureConfig = await polyfillLibrary.describePolyfill(feature);
+      const browsersWithoutFeature = featureConfig.browsers;
+      const allSupportedBrowsersSupportFeatureNatively = supportedBrowsers.every(
+        ([name, version]) => {
+          if (name in browsersWithoutFeature) {
+            const browserRangeWithoutFeature = browsersWithoutFeature[name];
+            if (semver.satisfies(version, browserRangeWithoutFeature)) {
+              console.log(
+                name,
+                version.toString(),
+                "does not support",
+                feature
+              );
+              return false;
+            } else {
+              console.log(name, version.toString(), "supports", feature);
+              return true;
             }
+          } else {
+            if (name in browserBaselines) {
+              console.log(name, version.toString(), "supports", feature);
+              return true;
+            } else {
+              console.log(
+                "we do not know if",
+                name,
+                version.toString(),
+                "supports",
+                feature
+              );
+              return false;
+            }
+          }
         }
+      );
+
+      if (allSupportedBrowsersSupportFeatureNatively) {
+        featuresInPolyfillLibrary.delete(feature);
+      }
     }
+  }
+  // Sort array of strings alphabetically
+  const sortedFeatures = Array.from(featuresInPolyfillLibrary).sort(function(
+    a,
+    b
+  ) {
+    return a.localeCompare(b);
+  });
 
-    // Sort array of strings alphabetically
-    const sortedFeatures = Array.from(featuresInPolyfillLibrary).sort(function (a, b) {
-        return a.localeCompare(b);
-    });
-
-    return `${polyfillUrl}?features=${sortedFeatures.join(',')}`;
+  if (sortedFeatures.length === 0) {
+    return "You do not need to use polyfill.io as all your supported browsers support all the features your website currently uses.";
+  } else {
+    return `${polyfillUrl}?features=${sortedFeatures.join(",")}`;
+  }
 }
 
-module.exports = generatePolyfillURL
+module.exports = generatePolyfillURL;


### PR DESCRIPTION
If a browserslists config is found in CWD or any parent folder we now check if every supported
browser requires a polyfill for a detected feature in the javascript bundle and if none do, we do
not add the feature to the polyfill.io url.

BREAKING CHANGE: If your project makes use of browserslist, you need to now check that you are happy
with your polyfill.io url being based on that config.

fix #10