### PR TITLE
Fix error when featureConfig is not found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ async function generatePolyfillURL(features = [], supportedBrowsers = []) {
   if (supportedBrowsers.length > 0) {
     for (const feature of featuresInPolyfillLibrary) {
       const featureConfig = await polyfillLibrary.describePolyfill(feature);
-      const browsersWithoutFeature = featureConfig.browsers;
+      const browsersWithoutFeature = featureConfig ? featureConfig.browsers : {};
       const allSupportedBrowsersSupportFeatureNatively = supportedBrowsers.every(
         ([name, version]) => {
           if (name in browsersWithoutFeature) {


### PR DESCRIPTION
Some features does not return any `featureConfig`, and thus `featureConfig.browsers` call throw an error.

Exemple of features without description : `URLSearchParams`, `Object.getOwnPropertySymbols`, `DataView`, `ArrayBuffer`.

I think a fix should be made in the polyfill to make those work, but as we do not know what can return or not return, the simple way here is to return an empty browser list for those features.