### PR TITLE
allow multiple files to be parsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ This project requires [Node.js] 10.x and [npm]. You can run it with:
 > npx create-polyfill-service-url analyse --file bundle.js
 ```
 
+You can pass multiple files as argument if you split your bundle files:
+
+```bash
+npx create-polyfill-service-url analyse --file app.js vendor.js
+```
+
 ## Contributing
 
 This module has a full suite of unit tests, and is verified with ESLint. You can use the following commands to check your code before opening a pull request:

--- a/index.js
+++ b/index.js
@@ -1,79 +1,110 @@
 #!/usr/bin/env node
 
-"use strict";
+'use strict';
 
-require("yargs")
-    .usage('$0 command')
-    .command('analyse', 'Analyse a JavaScript file and generate a polyfill.io URL based on all the features that are being used from within the JavaScript file.', {
-        file: {
-            string: true,
-            describe: 'The file that should be analysed',
-            demandOption: true
-        }
-    }, async function parseFile(argv) {
-        const browserslist = require('browserslist');
-        const browsersListConfig = browserslist.loadConfig({
-            path:  process.cwd()
-        })
-        let browsers = []
-        if (browsersListConfig) {
-            browsers = browserslist(browsersListConfig);
-        }
+require('yargs')
+  .usage('$0 command')
+  .command(
+    'analyse',
+    'Analyse a JavaScript file and generate a polyfill.io URL based on all the features that are being used from within the JavaScript file.',
+    {
+      file: {
+        array: true,
+        string: true,
+        describe: 'The file that should be analysed',
+        demandOption: true,
+      },
+    },
+    async function parseFile(argv) {
+      const browserslist = require('browserslist');
+      const browsersListConfig = browserslist.loadConfig({
+        path: process.cwd(),
+      });
+      let browsers = [];
+      if (browsersListConfig) {
+        browsers = browserslist(browsersListConfig);
+      }
 
-        const generatePolyfillURL = require('./src/index.js');
-        const path = require('path');
-        const babel = require("@babel/core");
-        const plugin = require('@financial-times/js-features-analyser/src/index.js');
-        const fs = require('fs');
-        const os = require('os');
-        const promisify = require('util').promisify;
-        const readFile = promisify(fs.readFile);
-        const mkdtemp = promisify(fs.mkdtemp);
-        
-        const file = path.join(process.cwd(), argv.file);
+      const generatePolyfillURL = require('./src/index.js');
+      const path = require('path');
+      const babel = require('@babel/core');
+      const plugin = require('@financial-times/js-features-analyser/src/index.js');
+      const fs = require('fs');
+      const os = require('os');
+      const promisify = require('util').promisify;
+      const readFile = promisify(fs.readFile);
+      const mkdtemp = promisify(fs.mkdtemp);
+
+      const promiseList = argv.file.map(async filename => {
+        const file = path.join(process.cwd(), filename);
         const fileContents = await readFile(file, 'utf-8');
-        const tempFolder = await mkdtemp(path.join(os.tmpdir(), 'js-features-analyser'));
+        const tempFolder = await mkdtemp(
+          path.join(os.tmpdir(), 'js-features-analyser')
+        );
         const outputDestination = path.join(tempFolder, 'features.json');
 
         try {
-            babel.transformSync(fileContents, {
-                plugins: [
-                    [
-                        plugin, {
-                            outputDestination
-                        }
-                    ]
-                ],
-                filename: file,
-                ast: false,
-                code: false
-            });
-            
-            const result = await generatePolyfillURL(JSON.parse(fs.readFileSync(outputDestination, 'utf-8')), browsers);
-            
-            if (result.type === generatePolyfillURL.TYPE_URL) {
-                console.log(result.message);
-            } else if (result.type === generatePolyfillURL.TYPE_NOTHING) {
-                console.error(result.message)
-            }
+          babel.transformSync(fileContents, {
+            plugins: [
+              [
+                plugin,
+                {
+                  outputDestination,
+                },
+              ],
+            ],
+            filename: file,
+            ast: false,
+            code: false,
+          });
+
+          return JSON.parse(fs.readFileSync(outputDestination, 'utf-8'));
         } catch (error) {
-            if (error instanceof SyntaxError) {
-                console.error("Failed to parse the JavaScript from xxx because it has a syntax error.")
-                delete error.stack;
-                delete error.code;
-                delete error.pos;
-                delete error.loc;
-                const result = /: (?<errorType>[\w ]+) \((?<position>\d+:\d+)\)/.exec(error.message);
-                console.error(result.groups.errorType)
-                error.message = error.message.replace(` ${result.groups.errorType} `, '');
-                error.message = error.message.replace(`(${result.groups.position})`, result.groups.position);
-                console.error(error.message);
-            } else {
-                console.error("Failed to parse the JavaScript from xxx because an error occured:")
-                console.error(error);
-            }
+          if (error instanceof SyntaxError) {
+            console.error(
+              'Failed to parse the JavaScript from xxx because it has a syntax error.'
+            );
+            delete error.stack;
+            delete error.code;
+            delete error.pos;
+            delete error.loc;
+            const result = /: (?<errorType>[\w ]+) \((?<position>\d+:\d+)\)/.exec(
+              error.message
+            );
+            console.error(result.groups.errorType);
+            error.message = error.message.replace(
+              ` ${result.groups.errorType} `,
+              ''
+            );
+            error.message = error.message.replace(
+              `(${result.groups.position})`,
+              result.groups.position
+            );
+            console.error(error.message);
+          } else {
+            console.error(
+              'Failed to parse the JavaScript from xxx because an error occured:'
+            );
+            console.error(error);
+          }
         }
-    })
-    .help()
-    .strict()
-    .argv;
+      });
+
+      const resultList = await Promise.all(promiseList);
+      const featureList = resultList.reduce(
+        (carry, item) => [...carry, ...item],
+        []
+      );
+      const uniqueFeatureList = [...new Set(featureList)];
+
+      const result = await generatePolyfillURL(uniqueFeatureList, browsers);
+
+      if (result.type === generatePolyfillURL.TYPE_URL) {
+        console.log(result.message);
+      } else if (result.type === generatePolyfillURL.TYPE_NOTHING) {
+        console.error(result.message);
+      }
+    }
+  )
+  .help()
+  .strict().argv;


### PR DESCRIPTION
Features like [webpack code splitting](https://webpack.js.org/guides/code-splitting/) will output several files.
I added the possibility to take multiple input files for the `--file` argument.

A future interesting possibility will be to take a wildcard pattern : `public/js/**/*.js`

You can review the PR with the "Hide whitespace changes" filter ON to make it understandable 😃 
