### PR TITLE
Allow programmatic usage by exporting the library file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "create-polyfill-service-url",
   "bin": "./index.js",
+  "main": "./src/index.js",
   "scripts": {
     "fix": "eslint . --fix",
     "lint": "eslint .",


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/polyfill-service-url-builder/issues/41