### PR TITLE
Fix error when polyfill is missing browsers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ async function generatePolyfillURL(features = [], supportedBrowsers = []) {
   if (supportedBrowsers.length > 0) {
     for (const feature of featuresInPolyfillLibrary) {
       const featureConfig = await polyfillLibrary.describePolyfill(feature);
-      const browsersWithoutFeature = featureConfig ? featureConfig.browsers : {};
+      const browsersWithoutFeature = featureConfig && featureConfig.browsers ? featureConfig.browsers : {};
       const allSupportedBrowsersSupportFeatureNatively = supportedBrowsers.every(
         ([name, version]) => {
           if (name in browsersWithoutFeature) {


### PR DESCRIPTION
First of all thank you for polyfill-library :)

I encountered a small issue with this script:

When a polyfill is missing the "browsers" definition in its toml, this script fails with the following error:
```
TypeError: Cannot use 'in' operator to search for '<browser>' in undefined
    at <path-to>/node_modules/create-polyfill-service-url/src/index.js:109:20
```

I found it because the "AudioContext" polyfill is missing the "browsers" definition in it's toml:
https://github.com/Financial-Times/polyfill-library/blob/master/polyfills/AudioContext/config.toml

I thought it's better to fix this here, since it would protect against this issue with other polyfills.
