### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3954,9 +3954,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
     },
     "inquirer": {
       "version": "7.3.3",


### PR DESCRIPTION
### Updated (1)

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [ini](https://npm.im/ini) | `1.3.5` → `1.3.7` | [github](https://github.com/isaacs/ini) | **[Low]** Prototype Pollution ([ref](https://npmjs.com/advisories/1589)) |

***

This pull request is created by [npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action). The used npm version is **6.14.8**.